### PR TITLE
Resolving E_Strict Standards

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -1,7 +1,7 @@
 <?php
 class BPMultiNetworkComponent extends BP_Component{
     private static $instance;
-    
+
     public static function get_instance() {
         if (!isset(self::$instance)) {
             self::$instance = new self();
@@ -9,23 +9,23 @@ class BPMultiNetworkComponent extends BP_Component{
         return self::$instance;
     }
     private function __construct() {
-       
+
         parent::start(
                 'mnetwork',//unique id
                 __( 'Network', 'mnetwork' ),
                 untrailingslashit(BP_MNETWORK_DIR)//base path
         );
     }
-    function setup_globals() {
+    function setup_globals( $globals = array() ) {
         global $bp,$wpdb;
-            
+
         // Define a slug, if necessary
         if ( !defined( 'BP_MNETWORK_SLUG' ) )
             define( 'BP_MNETWORK_SLUG', $this->id );
 
             $global_tables = array(
 			'table_network_users'  => mnetwork_get_table_name(),//these tables can be accessed from $bp->mnetwork->table_name
-			
+
 		);
 
 		//all other globals
@@ -40,28 +40,28 @@ class BPMultiNetworkComponent extends BP_Component{
 		);
 
 		parent::setup_globals( $globals );//it will call do_action("bp_gallery_setup_global") after setting up the constants properly
-                
-                 
-                
-                
+
+
+
+
         }//end of setup global
-        
+
          /**
      * Include files
      */
-    function includes() {
+    function includes( $includes = array() ) {
 
    	$includes = array();
-                
+
    }
 
         //do we really need it ? No, if we don't want to list the networks on user profile
-        function setup_nav() {
+        function setup_nav( $main_nav = array(), $sub_nav = array() ) {
             global $bp;
-            
+
             //sorry I am not putting it in the initial version, if the community suggests I will be happy to add a My Network Tab
             return false;
-    
+
             // Add 'Networks' to the user's main navigation
             $main_nav = array(
 			'name'                => sprintf( __( 'Networks <span>%d</span>', 'mnetwork' ),2 ),// bp_get_total_networks_for_user()
@@ -72,7 +72,7 @@ class BPMultiNetworkComponent extends BP_Component{
 			'item_css_id'         => $this->id
 		);
 
-            $gallery_link = trailingslashit( $bp->loggedin_user->domain . $this->slug );//with a trailing slash
+			$gallery_link = trailingslashit( $bp->loggedin_user->domain . $this->slug );//with a trailing slash
 
 		// Add the My Groups nav item
             $sub_nav[] = array(
@@ -85,14 +85,14 @@ class BPMultiNetworkComponent extends BP_Component{
                     'item_css_id'     => 'mnetwork-my-networks'
             );
 
-            
-            
+
+
             //if this is single gallery, add edit gallery link too!
-            // 
+            //
 
 	 parent::setup_nav( $main_nav, $sub_nav );
-         
-       
+
+
          do_action( 'mnetwork_setup_nav');
 	}
 }


### PR DESCRIPTION
The plugin was throwing a number of E_STRICT standard errors in the log because of the invalid inheritance of BPMultiNetworkComponent from BP_Component class.
Have changed the function signatures of setup_globals, includes and setup_nav to avoid those errors.
